### PR TITLE
feat: a rule to check locale key and Eng translation matches

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -45,8 +45,8 @@ impl Checker {
             } else {
                 for (rule, errors) in ERROR_STORAGE.iter() {
                     println!("  {}", rule);
-                    for (key, error) in errors {
-                        println!("    {}: {}", key, error);
+                    for key in errors {
+                        println!("    {}", key);
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod rules;
 
 use crate::checker::Checker;
 use crate::parse::LocalizedTexts;
+use crate::rules::key_and_en_matches::KeyEnMatches;
 use crate::rules::missing_translations::MissingTranslations;
 use serde_yaml_ng::from_reader;
 use serde_yaml_ng::Value as Yaml;
@@ -28,6 +29,7 @@ fn main() {
 
     let mut checker = Checker::new();
     checker.register_rule(MissingTranslations);
+    checker.register_rule(KeyEnMatches);
 
     checker.check(&localized_texts);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,7 @@ use std::fs::File;
 
 fn main() {
     let file_name = args()
-        .skip(1)
-        .next()
+        .nth(1)
         .expect("Error: a yaml file should be specified");
     let file = File::open(&file_name).unwrap_or_else(|e| {
         panic!(

--- a/src/rules/key_and_en_matches.rs
+++ b/src/rules/key_and_en_matches.rs
@@ -26,11 +26,9 @@ impl Rule for KeyEnMatches {
     }
 }
 
-const LEFT_BRACE: &str = "{";
-const RIGHT_BRACE: &str = "}";
-
 mod parser {
-    use super::{LEFT_BRACE, RIGHT_BRACE};
+    const LEFT_BRACE: &str = "{";
+    const RIGHT_BRACE: &str = "}";
 
     /// A locale token in the key.
     #[derive(Debug, PartialEq, Eq)]

--- a/src/rules/key_and_en_matches.rs
+++ b/src/rules/key_and_en_matches.rs
@@ -1,0 +1,283 @@
+use parser::{LocaleKeyParser, LocaleToken};
+
+use super::Rule;
+
+/// A rules that enforces a locale's key matches its English translation.
+///
+/// This is requested by rust-i18n (The i18n framework Topgrade uses), it is simply
+/// our convention.
+pub(crate) struct KeyEnMatches;
+
+impl Rule for KeyEnMatches {
+    fn check(&self, localized_texts: &crate::parse::LocalizedTexts) {
+        for (key, translations) in localized_texts.texts.iter() {
+            let en = translations
+                .en
+                .as_ref()
+                .expect("expect translation en to be provided");
+            let mut parser = LocaleKeyParser::new();
+            parser.parse(key);
+            let expected = key_to_en(&parser);
+
+            if en != &expected {
+                Self::report_error(key.clone())
+            }
+        }
+    }
+}
+
+const LEFT_BRACE: &str = "{";
+const RIGHT_BRACE: &str = "}";
+
+mod parser {
+    use super::{LEFT_BRACE, RIGHT_BRACE};
+
+    /// A locale token in the key.
+    #[derive(Debug, PartialEq, Eq)]
+    pub(crate) enum LocaleToken<'token> {
+        /// It is not surrounded by a pair of braces
+        WithoutBrace(&'token str),
+        /// It is surrounded by a pair of braces
+        WithinBrace(&'token str),
+    }
+
+    /// Key parser.
+    #[derive(Debug, PartialEq, Eq)]
+    pub(crate) struct LocaleKeyParser<'input> {
+        /// tokens
+        tokens: Vec<LocaleToken<'input>>,
+    }
+
+    impl<'input> LocaleKeyParser<'input> {
+        /// Create a parser with nothing.
+        pub(crate) fn new() -> Self {
+            Self { tokens: Vec::new() }
+        }
+
+        /// Accesses the parsed tokens.
+        pub(crate) fn tokens(&self) -> &[LocaleToken<'input>] {
+            &self.tokens
+        }
+
+        /// Parses the `input`, stores the parsed tokens in `self`.
+        pub(crate) fn parse<'slf>(&'slf mut self, input: &'input str) {
+            let len = input.len();
+            let mut start_offset = 0;
+
+            while start_offset < len {
+                let opt_left_brace_location = input[start_offset..].find(LEFT_BRACE);
+
+                match opt_left_brace_location {
+                    None => {
+                        self.tokens
+                            .push(LocaleToken::WithoutBrace(&input[start_offset..]));
+                        return;
+                    }
+                    Some(mut left_brace_location) => {
+                        left_brace_location += start_offset;
+
+                        let opt_right_brace_location =
+                            input[left_brace_location..].find(RIGHT_BRACE);
+
+                        match opt_right_brace_location {
+                            None => {
+                                self.tokens
+                                    .push(LocaleToken::WithoutBrace(&input[start_offset..]));
+                                return;
+                            }
+                            Some(mut right_brace_location) => {
+                                right_brace_location += left_brace_location;
+                                // handle the part without brace
+                                if left_brace_location != start_offset {
+                                    self.tokens.push(LocaleToken::WithoutBrace(
+                                        &input[start_offset..left_brace_location],
+                                    ));
+                                }
+
+                                self.tokens.push(LocaleToken::WithinBrace(
+                                    &input[left_brace_location + 1..=right_brace_location - 1],
+                                ));
+
+                                start_offset = right_brace_location + 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn no_brace() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("without_any_brace");
+
+            for token in parser.tokens() {
+                assert!(matches!(token, LocaleToken::WithoutBrace(_)));
+            }
+        }
+
+        #[test]
+        fn starts_with_brace() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("{brace}topgrade");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![
+                    LocaleToken::WithinBrace("brace"),
+                    LocaleToken::WithoutBrace("topgrade"),
+                ],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn ends_with_brace() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("topgrade{brace}");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![
+                    LocaleToken::WithoutBrace("topgrade"),
+                    LocaleToken::WithinBrace("brace"),
+                ],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn brace_in_the_middle() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("topgrade{brace}topgrade");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![
+                    LocaleToken::WithoutBrace("topgrade"),
+                    LocaleToken::WithinBrace("brace"),
+                    LocaleToken::WithoutBrace("topgrade"),
+                ],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn continuous_braces() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("{brace}{brace}");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![
+                    LocaleToken::WithinBrace("brace"),
+                    LocaleToken::WithinBrace("brace"),
+                ],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn continuous_braces_in_the_middle() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("topgrade{brace}{brace}topgrade");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![
+                    LocaleToken::WithoutBrace("topgrade"),
+                    LocaleToken::WithinBrace("brace"),
+                    LocaleToken::WithinBrace("brace"),
+                    LocaleToken::WithoutBrace("topgrade"),
+                ],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn single_left_brace() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("{");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![LocaleToken::WithoutBrace("{")],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn mutliple_left_brace() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("x{x{x{");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![LocaleToken::WithoutBrace("x{x{x{")],
+            };
+
+            assert_eq!(parser, expected);
+        }
+
+        #[test]
+        fn a_pair_in_chaos() {
+            let mut parser = LocaleKeyParser::new();
+            parser.parse("}{x{x}{{x{");
+
+            let expected = LocaleKeyParser {
+                tokens: vec![
+                    LocaleToken::WithoutBrace("}"),
+                    LocaleToken::WithinBrace("x{x"),
+                    LocaleToken::WithoutBrace("{{x{"),
+                ],
+            };
+
+            assert_eq!(parser, expected);
+        }
+    }
+}
+
+/// Helper function to convert a locale key to its English translation by
+/// prepending a `%` to the tokens serrounded by `{}`.
+fn key_to_en(parser: &parser::LocaleKeyParser<'_>) -> String {
+    let mut ret = String::new();
+    for token in parser.tokens() {
+        match token {
+            LocaleToken::WithinBrace(str) => {
+                std::fmt::write(&mut ret, format_args!("%{{{}}}", str)).unwrap()
+            }
+            LocaleToken::WithoutBrace(str) => {
+                std::fmt::write(&mut ret, format_args!("{}", str)).unwrap()
+            }
+        }
+    }
+
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use parser::LocaleKeyParser;
+
+    use super::*;
+
+    #[test]
+    fn preprend_percent_works() {
+        let mut parser = LocaleKeyParser::new();
+        parser.parse("hello, {topgrade}");
+
+        assert_eq!(key_to_en(&parser).as_str(), "hello, %{topgrade}");
+    }
+
+    #[test]
+    fn preprend_percent_works_without_brace() {
+        let mut parser = LocaleKeyParser::new();
+        parser.parse("hello, topgrade");
+
+        assert_eq!(key_to_en(&parser).as_str(), "hello, topgrade");
+    }
+}

--- a/src/rules/missing_translations.rs
+++ b/src/rules/missing_translations.rs
@@ -1,27 +1,13 @@
-use std::fmt::Display;
-
 use super::Rule;
 
 /// A rule that checks if there is any key that misses some translations.
 pub(crate) struct MissingTranslations;
 
-enum MissingLang {
-    En,
-}
-
-impl Display for MissingLang {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::En => write!(f, "Missing English(en) translation"),
-        }
-    }
-}
-
 impl Rule for MissingTranslations {
     fn check(&self, localized_texts: &crate::LocalizedTexts) {
         for (key, translations) in localized_texts.texts.iter() {
             if translations.en.is_none() {
-                Self::report_error(key.clone(), MissingLang::En.to_string())
+                Self::report_error(key.clone())
             }
         }
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod key_and_en_matches;
 pub(crate) mod missing_translations;
 
 use crate::LocalizedTexts;
@@ -5,7 +6,7 @@ use once_cell::sync::Lazy;
 use std::collections::{hash_map::Entry, HashMap};
 
 /// This is where errors found by [`Rule`]s are stored.
-pub(crate) static mut ERROR_STORAGE: Lazy<HashMap<String, Vec<(String, String)>>> =
+pub(crate) static mut ERROR_STORAGE: Lazy<HashMap<String, Vec<String>>> =
     Lazy::new(|| HashMap::new());
 
 /// Represents a rule that Topgrade's locale file should obey.
@@ -27,7 +28,7 @@ pub(crate) trait Rule {
     }
 
     /// Implementations should invoke this when found an error.
-    fn report_error(key: String, error_msg: String)
+    fn report_error(key: String)
     where
         Self: Sized, // remove it from the vtable
     {
@@ -36,10 +37,10 @@ pub(crate) trait Rule {
         unsafe {
             match ERROR_STORAGE.entry(Self::name().to_string()) {
                 Entry::Occupied(mut o) => {
-                    o.get_mut().push((key, error_msg));
+                    o.get_mut().push(key);
                 }
                 Entry::Vacant(v) => {
-                    v.insert(vec![(key, error_msg)]);
+                    v.insert(vec![key]);
                 }
             }
         }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -6,8 +6,7 @@ use once_cell::sync::Lazy;
 use std::collections::{hash_map::Entry, HashMap};
 
 /// This is where errors found by [`Rule`]s are stored.
-pub(crate) static mut ERROR_STORAGE: Lazy<HashMap<String, Vec<String>>> =
-    Lazy::new(|| HashMap::new());
+pub(crate) static mut ERROR_STORAGE: Lazy<HashMap<String, Vec<String>>> = Lazy::new(HashMap::new);
 
 /// Represents a rule that Topgrade's locale file should obey.
 ///


### PR DESCRIPTION
This PR adds a new rule to check if a locale key matches its English translation. If there is no `{}` in the key, then its English translation should have the same value as the key. Otherwise, its English translation should have an extra `%` before every `{}` in the key.

It looks like this works well:

```sh
$ cargo build
$ ./target/debug/topgrade_i18n_locale_file_checker test_file.yml
Errors Found:
  KeyEnMatches
    Path expanded to
    brl list: {output_stdout} {output_stderr}
    Bedrock distribution {distribution}
    Unknown distribution {distribution}
    Checking for gnome extensions: {output}
    Failed to canonicalize {profile_dir}
    Found Nix profile {profile_dir}
    WSL distributions: {wsl_distributions}
    Startup link: {link}
```