### PR TITLE
fix: should exit with non-zero on error

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -28,21 +28,30 @@ impl Checker {
         }
     }
 
+    /// Return true if there is no error.
+    pub(crate) fn has_error(&self) -> bool {
+        // SAFETY:
+        // It is safe to directly modify the global static variable as there is only 1 thread.
+        let n_errors: usize = unsafe {
+            ERROR_STORAGE
+                .iter()
+                .map(|(_key, errors)| errors.len())
+                .sum()
+        };
+
+        n_errors != 0
+    }
+
     /// Print the errors that are found in a human-readable way.
     pub(crate) fn report_to_user(&self) {
-        println!("Errors Found:");
-
         // SAFETY:
         // It is safe to directly modify the global static variable as there is only 1 thread.
         unsafe {
-            let n_errors: usize = ERROR_STORAGE
-                .iter()
-                .map(|(_key, errors)| errors.len())
-                .sum();
-
-            if n_errors == 0 {
-                println!("  No error");
+            if !self.has_error() {
+                println!("No error found!");
             } else {
+                println!("Errors Found:");
+
                 for (rule, errors) in ERROR_STORAGE.iter() {
                     println!("  {}", rule);
                     for (key, opt_error_msg) in errors {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,8 @@ use serde_yaml_ng::Value as Yaml;
 use std::env::args;
 use std::fs::File;
 
+const EXIT_CODE_ON_ERROR: i32 = 1;
+
 fn main() {
     let file_name = args()
         .nth(1)
@@ -33,4 +35,8 @@ fn main() {
     checker.check(&localized_texts);
 
     checker.report_to_user();
+
+    if checker.has_error() {
+        std::process::exit(EXIT_CODE_ON_ERROR);
+    }
 }


### PR DESCRIPTION
### What does this PR do

Before this PR, no matter if we found an error or not, we exit with 0. This would make running the checker in CI pointless, so fix it.

Now we exit with 1 on error.