### PR TITLE
chore: rename to topgrade_i18n_locale_checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "topgrade_i18n_locale_file_checker"
+name = "topgrade_i18n_locale_checker"
 version = "0.1.0"
 dependencies = [
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "topgrade_i18n_locale_file_checker"
+name = "topgrade_i18n_locale_checker"
 version = "0.1.0"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-A tool that is used to check Topgrade's i18n locale file.
+A tool that is used to check 
+
+1. Topgrade's i18n locale file.
+2. And the usages of `rust_i18n::t!()` in Topgrade's source code.


### PR DESCRIPTION
### What does this PR do

Rename the tool to `topgrade_i18n_locale_checker` as it no longer only checks the locale file since #6.