### PR TITLE
ci: add CI & pin toolchain

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,41 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+name: CI
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run cargo fmt
+        env:
+          TERM: xterm-256color
+        run: |
+          cargo fmt --all -- --check
+
+  main:
+    needs: fmt
+    name: ${{ matrix.runs_on }} (clippy, test)
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs_on: macos-latest
+          - runs_on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run cargo test
+        run: cargo test 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.76.0"


### PR DESCRIPTION
### What does this PR do

1. Pin the toolchain to the same one used by Topgrade.
2. Add CI to run `cargo fmt/clippy/test`.